### PR TITLE
updated Zeppelin build command for scala-2.11 profile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,9 @@ RUN git config --global url."https://".insteadOf git:// \
 
 WORKDIR $ZEPPELIN_HOME
 RUN git pull
-RUN mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Pscala-2.11 -DskipTests
+RUN ./dev/change_scala_version.sh 2.11 \
+  && mvn clean package -Pspark-2.0 -Phadoop-2.4 -Pyarn -Ppyspark -Psparkr -Pscala-2.11 -DskipTests \
+  && rm -rf ~/.m2
 
 EXPOSE 8080 8081 4040
 


### PR DESCRIPTION
Currently - since https://github.com/apache/zeppelin/commit/e8860cffabb6bc211ae81bc450dfb9e787b30a81#diff-04c6e90faac2675aa89e2176d2eec7d8R310 - Zeppelin build requires a bash script to be executed before changing Scala version from 2.10 to 2.11
